### PR TITLE
Fixes #9

### DIFF
--- a/lib/grommunio/grommunio.php
+++ b/lib/grommunio/grommunio.php
@@ -483,7 +483,7 @@ class Grommunio extends InterProcessData implements IBackend, ISearchProvider, I
 		// @see http://jira.zarafa.com/browse/ZP-68
 		$meetingRequestProps = MAPIMapping::GetMeetingRequestProperties();
 		$meetingRequestProps = getPropIdsFromStrings($this->defaultstore, $meetingRequestProps);
-		$props = mapi_getprops($mapimessage, [PR_MESSAGE_CLASS, $meetingRequestProps["goidtag"], $sendMailProps["internetcpid"], $sendMailProps["body"], $sendMailProps["html"], $sendMailProps["rtf"], $sendMailProps["rtfinsync"]]);
+		$props = mapi_getprops($mapimessage, [PR_MESSAGE_CLASS, $meetingRequestProps["goidtag"], $sendMailProps["internetcpid"], $sendMailProps["body"], $sendMailProps["html"], $sendMailProps["rtf"], $sendMailProps["rtfinsync"], $sendMailProps['emailaddress']]);
 
 		// If the device is WindowsMail and the FROM field is empty, use the user's primary email
 		// @see https://github.com/grommunio/grommunio-sync/issues/9


### PR DESCRIPTION
This fix adds the users primary email address to the sender address property in the MAPI message if the client is "WindowsMail" and the property is empty. See #9. Whilst I can't imagine a use case for sending as the system user over ActiveSync, I treat this as a quirk of WindowsMail and thus only modify the property if the User-Agent matches.