### PR TITLE
fix: Utf8_truncate crashes on empty strings due to off-by-one-error

### DIFF
--- a/lib/utils/utils.php
+++ b/lib/utils/utils.php
@@ -335,6 +335,11 @@ class Utils {
 	 * @return string truncated string
 	 */
 	public static function Utf8_truncate($string, $length, $htmlsafe = false) {
+		// skip empty strings
+		if (empty($string)) {
+			return "";
+		}
+
 		// make sure length is always an integer
 		$length = (int) $length;
 


### PR DESCRIPTION
`WARNING: [pool grommunio-sync-pool] child 111823 said into stderr: "NOTICE: PHP message: PHP Fatal error: Uncaught ValueError: strrpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack) in /usr/share/grommunio-sync/lib/utils/utils.php:352"`

When $string is empty the value $offset will be set to `-1`, which is not a valid position for strrpos.